### PR TITLE
fixes #25 - Adds extra_large and double_extra_large to the options fo…

### DIFF
--- a/plugins/modules/lm_collector.py
+++ b/plugins/modules/lm_collector.py
@@ -114,6 +114,8 @@ options:
             - small = 2GB
             - medium = 4GB
             - large = 8GB
+            - extra_large = 16GB
+            - double_extra_large = 32GB
             - Optional for action=add
         type: str
         default: 'small'
@@ -319,7 +321,9 @@ class Collector(LogicMonitorBaseModule):
             "nano",
             "small",
             "medium",
-            "large"
+            "large",
+            "extra_large",
+            "double_extra_large"
         ]
 
         module_args = dict(


### PR DESCRIPTION
…r collector size.

##### SUMMARY
Fixes #25 

Adds extra_large and double_extra_large collector size options to lm_collectors.py documentation and code.

##### ISSUE TYPE
- Feature Pull Request

##### COMPONENT NAME
lm_collectors.py

##### ADDITIONAL INFORMATION
Extra Large and Double Extra Large don't exist as options right now. They're options in the LM API, however, as extra_large and 
